### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      javascript:
+        patterns: ["*"]
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "build"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
     groups:
       javascript:
         patterns: ["*"]
+    ignore:
+      # deployed bytecode depends on the version; contract sources import OZ
+      - dependency-name: "@openzeppelin/contracts"
+      # stack in maintenance (ethers 5, hardhat 2, waffle 3, ts 4) — majors handled manually, not weekly
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "javascript"]
     commit-message:
       prefix: "build"

--- a/.github/workflows/verify-bytecode.yml
+++ b/.github/workflows/verify-bytecode.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Setup node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 18
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: node_modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Adds a Dependabot configuration for weekly grouped dependency updates:

- `github-actions`: weekly, grouped, 7-day cooldown
- `npm`: weekly, all dependencies grouped, 7-day cooldown
- `docker`: weekly base image updates, 7-day cooldown

Also pins all workflow actions to commit hashes and bumps them to latest releases:

| Action | Before | After |
|---|---|---|
| actions/checkout | v3 | v6.0.3 |
| actions/cache | v3 | v5.0.5 |
| actions/setup-node | v3 | v6.4.0 |