### PR TITLE
build: ignore ethereum-waffle major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
       # stack in maintenance (ethers 5, hardhat 2, waffle 3, ts 4) — majors handled manually, not weekly
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # ethereum-waffle v4 is a breaking migration tracked in #28 — also suppress security-driven ancestor bumps
+      - dependency-name: "ethereum-waffle"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "javascript"]
     commit-message:
       prefix: "build"


### PR DESCRIPTION
Suppress `ethereum-waffle` major bumps, including security-driven ancestor updates.

Dependabot security PRs (#27 `tar`, #26 `form-data`, #23 `cacheable-request`) could only remediate the vulnerable transitive deps by bumping `ethereum-waffle` `^3.4.0` → `^4.0.10` (breaking major) and `solidity-coverage` `^0.7.17` → `^0.8.17`. All are `devDependencies` (test/coverage tooling), so the advisories are dev/test-only and not in deployed bytecode.

The waffle v4 migration is tracked in #28. Until then, this adds an explicit major-ignore for `ethereum-waffle` so the breaking bump is not re-proposed. PRs #27/#26/#23 are closed.
